### PR TITLE
Support GHC 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 cabal.sandbox.config
 *.tix
 /.stack-work
+
+/example.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - env: RESOLVER=lts-4
     - env: RESOLVER=lts-5
     - env: RESOLVER=lts-6
+    - env: RESOLVER=lts-7
     - env: RESOLVER=nightly
   allow_failures:
     - env: RESOLVER=nightly

--- a/haiji.cabal
+++ b/haiji.cabal
@@ -33,7 +33,7 @@ library
                        Text.Haiji.Syntax.Identifier
                        Text.Haiji.Syntax.Expression
                        Text.Haiji.Syntax.Variable
-  build-depends:       base >=4.7 && <4.9
+  build-depends:       base >=4.7 && <5
                      , text
                      , attoparsec >=0.10
                      , template-haskell >=2.8

--- a/src/Text/Haiji/Syntax/Identifier.hs
+++ b/src/Text/Haiji/Syntax/Identifier.hs
@@ -20,35 +20,36 @@ instance IsString Identifier where
 --
 -- https://docs.python.org/2.7/reference/lexical_analysis.html#identifiers
 --
--- >>> let eval = either (error "parse error") id . parseOnly identifier
+-- >>> import Control.Arrow (left)
+-- >>> let eval = left (const "parse error") . parseOnly identifier
 -- >>> eval "a"
--- a
+-- Right a
 -- >>> eval "ab"
--- ab
+-- Right ab
 -- >>> eval "A"
--- A
+-- Right A
 -- >>> eval "Ab"
--- Ab
+-- Right Ab
 -- >>> eval "_"
--- _
+-- Right _
 -- >>> eval "_a"
--- _a
+-- Right _a
 -- >>> eval "_1"
--- _1
+-- Right _1
 -- >>> eval "__"
--- __
+-- Right __
 -- >>> eval "_ "
--- _
+-- Right _
 -- >>> eval " _"
--- *** Exception: parse error
+-- Left "parse error"
 -- >>> eval "and"
--- *** Exception: parse error
+-- Left "parse error"
 -- >>> eval "1"
--- *** Exception: parse error
+-- Left "parse error"
 -- >>> eval "1b"
--- *** Exception: parse error
+-- Left "parse error"
 -- >>> eval "'x"
--- *** Exception: parse error
+-- Left "parse error"
 --
 identifier :: Parser Identifier
 identifier = do

--- a/src/Text/Haiji/Syntax/Variable.hs
+++ b/src/Text/Haiji/Syntax/Variable.hs
@@ -16,29 +16,30 @@ instance Show Variable where
 
 -- |
 --
--- >>> let eval = either (error "parse error") id . parseOnly variable
+-- >>> import Control.Arrow (left)
+-- >>> let eval = left (const "parse error") . parseOnly variable
 -- >>> eval "foo"
--- foo
+-- Right foo
 -- >>> eval "foo.bar"
--- foo.bar
+-- Right foo.bar
 -- >>> eval "foo.b}}ar"
--- foo.b
+-- Right foo.b
 -- >>> eval "foo.b ar"
--- foo.b
+-- Right foo.b
 -- >>> eval "foo.b }ar"
--- foo.b
+-- Right foo.b
 -- >>> eval " foo.bar"
--- *** Exception: parse error
+-- Left "parse error"
 -- >>> eval "foo.  bar"
--- foo.bar
+-- Right foo.bar
 -- >>> eval "foo  .bar"
--- foo.bar
+-- Right foo.bar
 -- >>> eval "foo.bar  "
--- foo.bar
+-- Right foo.bar
 -- >>> eval "foo.bar  "
--- foo.bar
+-- Right foo.bar
 -- >>> eval "foo.bar.baz"
--- foo.bar.baz
+-- Right foo.bar.baz
 --
 variable :: Parser Variable
 variable = identifier >>= go . VariableBase where


### PR DESCRIPTION
This PR adds support for ghc-8.  After adjusting the version bounds in the cabal file, `haiji` builds on ghc-8 without a problem, but it has problems with the doctests.

The problem is https://github.com/sol/doctest/issues/136.  The suggested work-around doesn't work for older versions of ghc.

Rewriting the tests to use `Either` instead of `error` is slightly messy, but it works well on both old and new versions of ghc

Also, I made the following two small changes:
  -  I added `example.pyc` to the `.gitignore` file.  The `example.pyc` file is created when running the tests (at least on my system).
  - I added the `lts-7.0` resolver to the `.travis.yml` file.