### PR TITLE
add missing template files used by test-cases.

### DIFF
--- a/haiji.cabal
+++ b/haiji.cabal
@@ -14,7 +14,36 @@ maintainer:          Noriyuki OHKAWA <n.ohkawa@gmail.com>
 copyright:           Copyright (c) 2014-2019, Noriyuki OHKAWA
 category:            Text
 build-type:          Simple
--- extra-source-files:
+extra-source-files:  example.tmpl
+                     content.tmpl
+                     test/HTML_escape.tmpl
+                     test/arith.tmpl
+                     test/child.tmpl
+                     test/comment.tmpl
+                     test/comparison.tmpl
+                     test/condition.tmpl
+                     test/empty.tmpl
+                     test/filter.tmpl
+                     test/foreach.tmpl
+                     test/foreach_else_block.tmpl
+                     test/include.tmpl
+                     test/included_0LF.tmpl
+                     test/included_1LF.tmpl
+                     test/included_2LF.tmpl
+                     test/lf1.tmpl
+                     test/lf2.tmpl
+                     test/line_with_newline.tmpl
+                     test/line_without_newline.tmpl
+                     test/logic.tmpl
+                     test/loop_variables.tmpl
+                     test/many_variables.tmpl
+                     test/parent.tmpl
+                     test/range.tmpl
+                     test/raw.tmpl
+                     test/set.tmpl
+                     test/string.tmpl
+                     test/variables.tmpl
+                     test/whitespace_control.tmpl
 cabal-version:       >=1.10
 
 source-repository head

--- a/haiji.cabal
+++ b/haiji.cabal
@@ -14,7 +14,8 @@ maintainer:          Noriyuki OHKAWA <n.ohkawa@gmail.com>
 copyright:           Copyright (c) 2014-2019, Noriyuki OHKAWA
 category:            Text
 build-type:          Simple
-extra-source-files:  example.tmpl
+extra-source-files:  example.py
+                     example.tmpl
                      content.tmpl
                      test/HTML_escape.tmpl
                      test/arith.tmpl


### PR DESCRIPTION
Test cases reference a python script and template files, 
but source archive on hackage
(http://hackage.haskell.org/package/haiji-0.3.1.0/haiji-0.3.1.0.tar.gz) 
does not contain them.