### PR TITLE
lts-19.24

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,10 @@ jobs:
           - 'lts-13'
           - 'lts-14'
           - 'lts-15'
+          - 'lts-16'
+          - 'lts-17'
+          - 'lts-18'
+          - 'lts-19'
           - 'nightly'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,9 +7,14 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         resolver-version:
+          - 'lts-12'
+          - 'lts-13'
+          - 'lts-14'
+          - 'lts-15'
           - 'lts-16'
           - 'lts-17'
           - 'lts-18'
@@ -19,22 +24,22 @@ jobs:
       STACK_YAML: stack-travis.yaml
     steps:
     - uses: actions/checkout@v2
-    - name: Cache .stack
-      id: cache-stack
-      uses: actions/cache@v1
-      with:
-        path: ~/.stack
-        key: ${{ runner.os }}-stack-${{ matrix.resolver-version }}
-        restore-keys: |
-          ${{ runner.os }}-stack-
-    - name: Cache .local
-      id: cache-local
-      uses: actions/cache@v1
-      with:
-        path: ~/.local
-        key: ${{ runner.os }}-local-${{ matrix.resolver-version }}
-        restore-keys: |
-          ${{ runner.os }}-local-
+    # - name: Cache .stack
+    #   id: cache-stack
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.stack
+    #     key: ${{ runner.os }}-stack-${{ matrix.resolver-version }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-stack-
+    # - name: Cache .local
+    #   id: cache-local
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.local
+    #     key: ${{ runner.os }}-local-${{ matrix.resolver-version }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-local-
     # - uses: actions/setup-haskell@v1
     #   with:
     #     ghc-version: '8.8.2'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,22 +24,22 @@ jobs:
       STACK_YAML: stack-travis.yaml
     steps:
     - uses: actions/checkout@v2
-    # - name: Cache .stack
-    #   id: cache-stack
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.stack
-    #     key: ${{ runner.os }}-stack-${{ matrix.resolver-version }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-stack-
-    # - name: Cache .local
-    #   id: cache-local
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.local
-    #     key: ${{ runner.os }}-local-${{ matrix.resolver-version }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-local-
+    - name: Setup stack-travis.yaml
+      run: |
+        export RESOLVER=${{ matrix.resolver-version }}
+        ./latest $RESOLVER > stack-travis.yaml
+    - name: Cache .stack
+      id: cache-stack
+      uses: actions/cache@v3
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-stack-${{ hashFiles('stack-travis.yaml') }}
+    - name: Cache .local
+      id: cache-local
+      uses: actions/cache@v3
+      with:
+        path: ~/.local
+        key: ${{ runner.os }}-local-${{ hashFiles('stack-travis.yaml') }}
     # - uses: actions/setup-haskell@v1
     #   with:
     #     ghc-version: '8.8.2'
@@ -48,16 +48,10 @@ jobs:
       run: |
         mkdir -p ~/.local/bin
         export PATH=~/.local/bin:$PATH
-        export RESOLVER=${{ matrix.resolver-version }}
-        ./latest $RESOLVER > stack-travis.yaml
         curl -L https://www.stackage.org/stack/linux-x86_64 | \
         tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         stack update
         stack --no-terminal --skip-ghc-check setup
-    - name: Debug info
-      run: |
-        echo $RESOLVER
-        cat $STACK_YAML
     - name: Install deps
       run: |
         stack --no-terminal --skip-ghc-check test --only-snapshot

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,6 +19,8 @@ jobs:
           - 'lts-18'
           - 'lts-19'
           - 'nightly'
+    env:
+      STACK_YAML: stack-travis.yaml
     steps:
     - uses: actions/checkout@v2
     - name: Cache .stack
@@ -47,11 +49,14 @@ jobs:
         export PATH=~/.local/bin:$PATH
         export RESOLVER=${{ matrix.resolver-version }}
         ./latest $RESOLVER > stack-travis.yaml
-        export STACK_YAML=stack-travis.yaml
         curl -L https://www.stackage.org/stack/linux-x86_64 | \
         tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
         stack update
         stack --no-terminal --skip-ghc-check setup
+    - name: Debug info
+      run: |
+        echo $RESOLVER
+        cat $STACK_YAML
     - name: Install deps
       run: |
         stack --no-terminal --skip-ghc-check test --only-snapshot

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,14 +10,6 @@ jobs:
     strategy:
       matrix:
         resolver-version:
-          - 'lts-4'
-          - 'lts-5'
-          - 'lts-6'
-          - 'lts-7'
-          - 'lts-8'
-          - 'lts-9'
-          - 'lts-10'
-          - 'lts-11'
           - 'lts-12'
           - 'lts-13'
           - 'lts-14'
@@ -56,15 +48,9 @@ jobs:
         export RESOLVER=${{ matrix.resolver-version }}
         ./latest $RESOLVER > stack-travis.yaml
         export STACK_YAML=stack-travis.yaml
-        if [ ${RESOLVER/lts-/} -lt 10 ]
-        then
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.1/stack-1.9.1-linux-x86_64.tar.gz | \
-          tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-        else
-          curl -L https://www.stackage.org/stack/linux-x86_64 | \
-          tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-          stack update
-        fi
+        curl -L https://www.stackage.org/stack/linux-x86_64 | \
+        tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        stack update
         stack --no-terminal --skip-ghc-check setup
     - name: Install deps
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         resolver-version:
-          - 'lts-12'
-          - 'lts-13'
-          - 'lts-14'
-          - 'lts-15'
           - 'lts-16'
           - 'lts-17'
           - 'lts-18'

--- a/haiji.cabal
+++ b/haiji.cabal
@@ -91,6 +91,9 @@ test-suite doctests
   hs-source-dirs:      test
   ghc-options:         -Wall -threaded
   default-language:    Haskell2010
+  -- Skip doctest for GHC 9. https://github.com/sol/doctest/issues/327
+  if impl(ghc >= 9.0) && impl(ghc < 9.3)
+    buildable: False
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/haiji.cabal
+++ b/haiji.cabal
@@ -65,6 +65,7 @@ library
                        Text.Haiji.Syntax.Expression
                        Text.Haiji.Syntax.Literal
                        Text.Haiji.Syntax.Literal.String
+                       Text.Haiji.Utils
   build-depends:       base >=4.7 && <5
                      , text
                      , attoparsec >=0.10

--- a/src/Text/Haiji/Dictionary.hs
+++ b/src/Text/Haiji/Dictionary.hs
@@ -26,7 +26,6 @@ import Data.Maybe
 #else
 import Data.Monoid
 #endif
-import Data.String (fromString)
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import Data.Type.Bool
@@ -38,6 +37,7 @@ import Data.Kind
 #define STAR *
 #endif
 import GHC.TypeLits
+import Text.Haiji.Utils (toKey)
 
 data Key (k :: Symbol) where
   Key :: KnownSymbol k => Key k
@@ -74,7 +74,7 @@ instance ToJSON (Dict '[]) where
 instance (ToJSON (Dict d), ToJSON v, KnownSymbol k, Typeable v) => ToJSON (Dict ((k :-> v) ': d)) where
   toJSON dict = Object (a <> b) where
     (x, v, xs) = headKV dict
-    Object a = object [ fromString (keyVal x) .= v ]
+    Object a = object [ toKey (keyVal x) .= v ]
     Object b = toJSON xs
     headKV :: (KnownSymbol k, Typeable v) => Dict ((k :-> v) ': d) -> (Key k, v, Dict d)
     headKV (Dict d) = (k, fromJust $ fromDynamic $ d M.! keyVal k, Dict $ M.delete (keyVal k) d) where

--- a/src/Text/Haiji/Dictionary.hs
+++ b/src/Text/Haiji/Dictionary.hs
@@ -18,7 +18,7 @@ module Text.Haiji.Dictionary
        , retrieve
        ) where
 
-import Data.Aeson
+import Data.Aeson (ToJSON(..), Value(..), encode, object, (.=))
 import Data.Dynamic
 import qualified Data.HashMap.Strict as M
 import Data.Maybe
@@ -26,7 +26,7 @@ import Data.Maybe
 #else
 import Data.Monoid
 #endif
-import qualified Data.Text as T
+import Data.String (fromString)
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import Data.Type.Bool
@@ -74,7 +74,7 @@ instance ToJSON (Dict '[]) where
 instance (ToJSON (Dict d), ToJSON v, KnownSymbol k, Typeable v) => ToJSON (Dict ((k :-> v) ': d)) where
   toJSON dict = Object (a <> b) where
     (x, v, xs) = headKV dict
-    Object a = object [ T.pack (keyVal x) .= v ]
+    Object a = object [ fromString (keyVal x) .= v ]
     Object b = toJSON xs
     headKV :: (KnownSymbol k, Typeable v) => Dict ((k :-> v) ': d) -> (Key k, v, Dict d)
     headKV (Dict d) = (k, fromJust $ fromDynamic $ d M.! keyVal k, Dict $ M.delete (keyVal k) d) where

--- a/src/Text/Haiji/Runtime.hs
+++ b/src/Text/Haiji/Runtime.hs
@@ -20,17 +20,16 @@ import Control.Applicative
 #endif
 import Control.Monad.Trans.Reader
 import qualified Data.Aeson as JSON
-import qualified Data.Aeson.KeyMap as JSON
 import qualified Data.Aeson.Types as JSON
 import Data.Maybe
 import Data.Scientific
-import Data.String (fromString)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Vector as V
 import Text.Haiji.Parse
 import Text.Haiji.Syntax
 import Text.Haiji.Types
+import Text.Haiji.Utils
 
 -- | Dynamically template loader (for template development use)
 readTemplateFile :: Environment -> FilePath -> IO (Template JSON.Value)
@@ -72,8 +71,8 @@ haijiAST  env  parentBlock  children (Foreach k xs loopBody elseBody) =
               [ runReader (haijiASTs env parentBlock children loopBody)
                           (let JSON.Object obj = p
                            in  JSON.Object
-                               $ JSON.insert "loop" (loopVariables len ix)
-                               $ JSON.insert (fromString $ show k) x obj)
+                               $ insert_ "loop" (loopVariables len ix)
+                               $ insert_ (toKey $ show k) x obj)
               | (ix, x) <- zip [0..] (V.toList dicts)
               ]
          else maybe (return "") (haijiASTs env parentBlock children) elseBody
@@ -90,7 +89,7 @@ haijiAST  env  parentBlock  children (Set lhs rhs scopes) =
   do val <- eval rhs
      p <- ask
      return $ runReader (haijiASTs env parentBlock children scopes)
-       (let JSON.Object obj = p in  JSON.Object $ JSON.insert (fromString $ show lhs) val obj)
+       (let JSON.Object obj = p in  JSON.Object $ insert_ (toKey $ show lhs) val obj)
 
 loopVariables :: Integer -> Integer -> JSON.Value
 loopVariables len ix = JSON.object [ "first"     JSON..= (ix == 0)
@@ -109,7 +108,7 @@ eval (Expression expression) = go expression where
   go (ExprIntegerLiteral n) = return $ JSON.Number $ scientific n 0
   go (ExprStringLiteral s) = return $ JSON.String $ T.pack $ unwrap s
   go (ExprBooleanLiteral b) = return $ JSON.Bool b
-  go (ExprVariable v) = either error id . JSON.parseEither (JSON.withObject (show v) (JSON..: (fromString $ show v))) <$> ask
+  go (ExprVariable v) = either error id . JSON.parseEither (JSON.withObject (show v) (JSON..: (toKey $ show v))) <$> ask
   go (ExprParen e) = go e
   go (ExprRange [stop]) = do
     sstop <- either error id . JSON.parseEither (JSON.withScientific "range" return) <$> go stop
@@ -131,7 +130,7 @@ eval (Expression expression) = go expression where
       _             -> error "range"
   go (ExprRange _) = error "unreachable"
   go (ExprAttributed e []) = go e
-  go (ExprAttributed e attrs) = either error id . JSON.parseEither (JSON.withObject (show $ last attrs) (JSON..: (fromString $ show $ last attrs))) <$> go (ExprAttributed e $ init attrs)
+  go (ExprAttributed e attrs) = either error id . JSON.parseEither (JSON.withObject (show $ last attrs) (JSON..: (toKey $ show $ last attrs))) <$> go (ExprAttributed e $ init attrs)
   go (ExprFiltered e []) = go e
   go (ExprFiltered e filters) = applyFilter (last filters) $ ExprFiltered e $ init filters where
     applyFilter FilterAbs e' = either error id . JSON.parseEither (JSON.withScientific "abs" (return . JSON.Number . abs)) <$> go e'

--- a/src/Text/Haiji/Runtime.hs
+++ b/src/Text/Haiji/Runtime.hs
@@ -20,10 +20,11 @@ import Control.Applicative
 #endif
 import Control.Monad.Trans.Reader
 import qualified Data.Aeson as JSON
+import qualified Data.Aeson.KeyMap as JSON
 import qualified Data.Aeson.Types as JSON
 import Data.Maybe
-import qualified Data.HashMap.Strict as HM
 import Data.Scientific
+import Data.String (fromString)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Vector as V
@@ -71,8 +72,8 @@ haijiAST  env  parentBlock  children (Foreach k xs loopBody elseBody) =
               [ runReader (haijiASTs env parentBlock children loopBody)
                           (let JSON.Object obj = p
                            in  JSON.Object
-                               $ HM.insert "loop" (loopVariables len ix)
-                               $ HM.insert (T.pack $ show k) x obj)
+                               $ JSON.insert "loop" (loopVariables len ix)
+                               $ JSON.insert (fromString $ show k) x obj)
               | (ix, x) <- zip [0..] (V.toList dicts)
               ]
          else maybe (return "") (haijiASTs env parentBlock children) elseBody
@@ -89,7 +90,7 @@ haijiAST  env  parentBlock  children (Set lhs rhs scopes) =
   do val <- eval rhs
      p <- ask
      return $ runReader (haijiASTs env parentBlock children scopes)
-       (let JSON.Object obj = p in  JSON.Object $ HM.insert (T.pack $ show lhs) val obj)
+       (let JSON.Object obj = p in  JSON.Object $ JSON.insert (fromString $ show lhs) val obj)
 
 loopVariables :: Integer -> Integer -> JSON.Value
 loopVariables len ix = JSON.object [ "first"     JSON..= (ix == 0)
@@ -108,7 +109,7 @@ eval (Expression expression) = go expression where
   go (ExprIntegerLiteral n) = return $ JSON.Number $ scientific n 0
   go (ExprStringLiteral s) = return $ JSON.String $ T.pack $ unwrap s
   go (ExprBooleanLiteral b) = return $ JSON.Bool b
-  go (ExprVariable v) = either error id . JSON.parseEither (JSON.withObject (show v) (JSON..: (T.pack $ show v))) <$> ask
+  go (ExprVariable v) = either error id . JSON.parseEither (JSON.withObject (show v) (JSON..: (fromString $ show v))) <$> ask
   go (ExprParen e) = go e
   go (ExprRange [stop]) = do
     sstop <- either error id . JSON.parseEither (JSON.withScientific "range" return) <$> go stop
@@ -130,7 +131,7 @@ eval (Expression expression) = go expression where
       _             -> error "range"
   go (ExprRange _) = error "unreachable"
   go (ExprAttributed e []) = go e
-  go (ExprAttributed e attrs) = either error id . JSON.parseEither (JSON.withObject (show $ last attrs) (JSON..: (T.pack $ show $ last attrs))) <$> go (ExprAttributed e $ init attrs)
+  go (ExprAttributed e attrs) = either error id . JSON.parseEither (JSON.withObject (show $ last attrs) (JSON..: (fromString $ show $ last attrs))) <$> go (ExprAttributed e $ init attrs)
   go (ExprFiltered e []) = go e
   go (ExprFiltered e filters) = applyFilter (last filters) $ ExprFiltered e $ init filters where
     applyFilter FilterAbs e' = either error id . JSON.parseEither (JSON.withScientific "abs" (return . JSON.Number . abs)) <$> go e'

--- a/src/Text/Haiji/Runtime.hs
+++ b/src/Text/Haiji/Runtime.hs
@@ -71,8 +71,8 @@ haijiAST  env  parentBlock  children (Foreach k xs loopBody elseBody) =
               [ runReader (haijiASTs env parentBlock children loopBody)
                           (let JSON.Object obj = p
                            in  JSON.Object
-                               $ insert_ "loop" (loopVariables len ix)
-                               $ insert_ (toKey $ show k) x obj)
+                               $ insertValue "loop" (loopVariables len ix)
+                               $ insertValue (toKey $ show k) x obj)
               | (ix, x) <- zip [0..] (V.toList dicts)
               ]
          else maybe (return "") (haijiASTs env parentBlock children) elseBody
@@ -89,7 +89,7 @@ haijiAST  env  parentBlock  children (Set lhs rhs scopes) =
   do val <- eval rhs
      p <- ask
      return $ runReader (haijiASTs env parentBlock children scopes)
-       (let JSON.Object obj = p in  JSON.Object $ insert_ (toKey $ show lhs) val obj)
+       (let JSON.Object obj = p in  JSON.Object $ insertValue (toKey $ show lhs) val obj)
 
 loopVariables :: Integer -> Integer -> JSON.Value
 loopVariables len ix = JSON.object [ "first"     JSON..= (ix == 0)

--- a/src/Text/Haiji/Utils.hs
+++ b/src/Text/Haiji/Utils.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+module Text.Haiji.Utils where
+
+import qualified Data.Aeson as JSON
+
+#if MIN_VERSION_aeson(2,0,0)
+import Data.String (fromString)
+import qualified Data.Aeson.KeyMap as JSON
+
+toKey :: String -> JSON.Key
+toKey = fromString
+
+insert_ :: JSON.Key -> JSON.Value -> JSON.KeyMap JSON.Value -> JSON.KeyMap JSON.Value
+insert_ = JSON.insert
+
+#else
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HM
+
+toKey :: String -> T.Text
+toKey = T.pack
+
+insert_ :: T.Text -> JSON.Value -> HM.HashMap T.Text JSON.Value -> HM.HashMap T.Text JSON.Value
+insert_ = HM.insert
+#endif
+
+
+

--- a/src/Text/Haiji/Utils.hs
+++ b/src/Text/Haiji/Utils.hs
@@ -10,8 +10,8 @@ import qualified Data.Aeson.KeyMap as JSON
 toKey :: String -> JSON.Key
 toKey = fromString
 
-insert_ :: JSON.Key -> JSON.Value -> JSON.KeyMap JSON.Value -> JSON.KeyMap JSON.Value
-insert_ = JSON.insert
+insertValue :: JSON.Key -> JSON.Value -> JSON.KeyMap JSON.Value -> JSON.KeyMap JSON.Value
+insertValue = JSON.insert
 
 #else
 import qualified Data.Text as T
@@ -20,8 +20,8 @@ import qualified Data.HashMap.Strict as HM
 toKey :: String -> T.Text
 toKey = T.pack
 
-insert_ :: T.Text -> JSON.Value -> HM.HashMap T.Text JSON.Value -> HM.HashMap T.Text JSON.Value
-insert_ = HM.insert
+insertValue :: T.Text -> JSON.Value -> HM.HashMap T.Text JSON.Value -> HM.HashMap T.Text JSON.Value
+insertValue = HM.insert
 #endif
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-15.2
+resolver: lts-19.24
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION

- Update resolver to lts-19.24.
- Drop old resolvers in CI.
  - Old stack fails to download build plan from stackage.
  - https://github.com/ishiy1993/haiji/actions/runs/3087777392/jobs/4993593686
- Skip doctest for GHC 9.
  - https://github.com/sol/doctest/issues/327
- CI passed
  - https://github.com/ishiy1993/haiji/actions/runs/3095327049

